### PR TITLE
Adds simple apis for creating, listing, updating, deleting tasks

### DIFF
--- a/apps/whats_up/lib/whats_up/directory.ex
+++ b/apps/whats_up/lib/whats_up/directory.ex
@@ -1,0 +1,104 @@
+defmodule WhatsUp.Directory do
+  @moduledoc """
+  The Directory context.
+  """
+
+  import Ecto.Query, warn: false
+  alias WhatsUp.Repo
+
+  alias WhatsUp.Directory.Task
+
+  @doc """
+  Returns the list of tasks.
+
+  ## Examples
+
+      iex> list_tasks()
+      [%Task{}, ...]
+
+  """
+  def list_tasks do
+    Repo.all(Task)
+  end
+
+  @doc """
+  Gets a single task.
+
+  Raises `Ecto.NoResultsError` if the Task does not exist.
+
+  ## Examples
+
+      iex> get_task!(123)
+      %Task{}
+
+      iex> get_task!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_task!(id), do: Repo.get!(Task, id)
+
+  @doc """
+  Creates a task.
+
+  ## Examples
+
+      iex> create_task(%{field: value})
+      {:ok, %Task{}}
+
+      iex> create_task(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_task(attrs \\ %{}) do
+    %Task{}
+    |> Task.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a task.
+
+  ## Examples
+
+      iex> update_task(task, %{field: new_value})
+      {:ok, %Task{}}
+
+      iex> update_task(task, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_task(%Task{} = task, attrs) do
+    task
+    |> Task.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a task.
+
+  ## Examples
+
+      iex> delete_task(task)
+      {:ok, %Task{}}
+
+      iex> delete_task(task)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_task(%Task{} = task) do
+    Repo.delete(task)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking task changes.
+
+  ## Examples
+
+      iex> change_task(task)
+      %Ecto.Changeset{data: %Task{}}
+
+  """
+  def change_task(%Task{} = task, attrs \\ %{}) do
+    Task.changeset(task, attrs)
+  end
+end

--- a/apps/whats_up/lib/whats_up/directory/task.ex
+++ b/apps/whats_up/lib/whats_up/directory/task.ex
@@ -1,0 +1,19 @@
+defmodule WhatsUp.Directory.Task do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "tasks" do
+    field :creator_id, :integer
+    field :name, :string
+    field :upvote_count, :integer
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(task, attrs) do
+    task
+    |> cast(attrs, [:name, :upvote_count, :creator_id])
+    |> validate_required([:name, :upvote_count, :creator_id])
+  end
+end

--- a/apps/whats_up/priv/repo/migrations/20200518183525_create_tasks.exs
+++ b/apps/whats_up/priv/repo/migrations/20200518183525_create_tasks.exs
@@ -1,0 +1,14 @@
+defmodule WhatsUp.Repo.Migrations.CreateTasks do
+  use Ecto.Migration
+
+  def change do
+    create table(:tasks) do
+      add :name, :string
+      add :upvote_count, :integer
+      add :creator_id, :integer
+
+      timestamps()
+    end
+
+  end
+end

--- a/apps/whats_up/priv/repo/seeds.exs
+++ b/apps/whats_up/priv/repo/seeds.exs
@@ -9,3 +9,10 @@
 #
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
+alias WhatsUp.Repo
+alias WhatsUp.Directory.Task
+
+Repo.insert! %Task{name: "Watching The office UK version", upvote_count: 2, creator_id: 1}
+Repo.insert! %Task{name: "Listining to TS", upvote_count: 3, creator_id: 2}
+Repo.insert! %Task{name: "Cooking some pasta", upvote_count: 5, creator_id: 1}
+Repo.insert! %Task{name: "Playing online games", upvote_count: 4, creator_id: 3}

--- a/apps/whats_up/test/whats_up/directory_test.exs
+++ b/apps/whats_up/test/whats_up/directory_test.exs
@@ -1,0 +1,68 @@
+defmodule WhatsUp.DirectoryTest do
+  use WhatsUp.DataCase
+
+  alias WhatsUp.Directory
+
+  describe "tasks" do
+    alias WhatsUp.Directory.Task
+
+    @valid_attrs %{creator_id: 42, name: "some name", upvote_count: 42}
+    @update_attrs %{creator_id: 43, name: "some updated name", upvote_count: 43}
+    @invalid_attrs %{creator_id: nil, name: nil, upvote_count: nil}
+
+    def task_fixture(attrs \\ %{}) do
+      {:ok, task} =
+        attrs
+        |> Enum.into(@valid_attrs)
+        |> Directory.create_task()
+
+      task
+    end
+
+    test "list_tasks/0 returns all tasks" do
+      task = task_fixture()
+      assert Directory.list_tasks() == [task]
+    end
+
+    test "get_task!/1 returns the task with given id" do
+      task = task_fixture()
+      assert Directory.get_task!(task.id) == task
+    end
+
+    test "create_task/1 with valid data creates a task" do
+      assert {:ok, %Task{} = task} = Directory.create_task(@valid_attrs)
+      assert task.creator_id == 42
+      assert task.name == "some name"
+      assert task.upvote_count == 42
+    end
+
+    test "create_task/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Directory.create_task(@invalid_attrs)
+    end
+
+    test "update_task/2 with valid data updates the task" do
+      task = task_fixture()
+      assert {:ok, %Task{} = task} = Directory.update_task(task, @update_attrs)
+      assert task.creator_id == 43
+      assert task.name == "some updated name"
+      assert task.upvote_count == 43
+    end
+
+    test "update_task/2 with invalid data returns error changeset" do
+      task = task_fixture()
+      assert {:error, %Ecto.Changeset{}} = Directory.update_task(task, @invalid_attrs)
+      assert task == Directory.get_task!(task.id)
+    end
+
+    test "delete_task/1 deletes the task" do
+      task = task_fixture()
+      assert {:ok, %Task{}} = Directory.delete_task(task)
+      assert_raise Ecto.NoResultsError, fn -> Directory.get_task!(task.id) end
+    end
+
+    test "change_task/1 returns a task changeset" do
+      task = task_fixture()
+      assert %Ecto.Changeset{} = Directory.change_task(task)
+    end
+  end
+end

--- a/apps/whats_up_web/lib/whats_up_web/controllers/fallback_controller.ex
+++ b/apps/whats_up_web/lib/whats_up_web/controllers/fallback_controller.ex
@@ -1,0 +1,22 @@
+defmodule WhatsUpWeb.FallbackController do
+  @moduledoc """
+  Translates controller action results into valid `Plug.Conn` responses.
+
+  See `Phoenix.Controller.action_fallback/1` for more details.
+  """
+  use WhatsUpWeb, :controller
+
+  def call(conn, {:error, %Ecto.Changeset{} = changeset}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(WhatsUpWeb.ChangesetView)
+    |> render("error.json", changeset: changeset)
+  end
+
+  def call(conn, {:error, :not_found}) do
+    conn
+    |> put_status(:not_found)
+    |> put_view(WhatsUpWeb.ErrorView)
+    |> render(:"404")
+  end
+end

--- a/apps/whats_up_web/lib/whats_up_web/controllers/task_controller.ex
+++ b/apps/whats_up_web/lib/whats_up_web/controllers/task_controller.ex
@@ -1,0 +1,43 @@
+defmodule WhatsUpWeb.TaskController do
+  use WhatsUpWeb, :controller
+
+  alias WhatsUp.Directory
+  alias WhatsUp.Directory.Task
+
+  action_fallback WhatsUpWeb.FallbackController
+
+  def index(conn, _params) do
+    tasks = Directory.list_tasks()
+    render(conn, "index.json", tasks: tasks)
+  end
+
+  def create(conn, %{"task" => task_params}) do
+    with {:ok, %Task{} = task} <- Directory.create_task(task_params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", Routes.task_path(conn, :show, task))
+      |> render("show.json", task: task)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    task = Directory.get_task!(id)
+    render(conn, "show.json", task: task)
+  end
+
+  def update(conn, %{"id" => id, "task" => task_params}) do
+    task = Directory.get_task!(id)
+
+    with {:ok, %Task{} = task} <- Directory.update_task(task, task_params) do
+      render(conn, "show.json", task: task)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    task = Directory.get_task!(id)
+
+    with {:ok, %Task{}} <- Directory.delete_task(task) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/apps/whats_up_web/lib/whats_up_web/router.ex
+++ b/apps/whats_up_web/lib/whats_up_web/router.ex
@@ -7,6 +7,7 @@ defmodule WhatsUpWeb.Router do
 
   scope "/api", WhatsUpWeb do
     pipe_through :api
+    resources "/tasks", TaskController, except: [:new, :edit]
   end
 
   pipeline :browser do

--- a/apps/whats_up_web/lib/whats_up_web/views/changeset_view.ex
+++ b/apps/whats_up_web/lib/whats_up_web/views/changeset_view.ex
@@ -1,0 +1,19 @@
+defmodule WhatsUpWeb.ChangesetView do
+  use WhatsUpWeb, :view
+
+  @doc """
+  Traverses and translates changeset errors.
+
+  See `Ecto.Changeset.traverse_errors/2` and
+  `WhatsUpWeb.ErrorHelpers.translate_error/1` for more details.
+  """
+  def translate_errors(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, &translate_error/1)
+  end
+
+  def render("error.json", %{changeset: changeset}) do
+    # When encoded, the changeset returns its errors
+    # as a JSON object. So we just pass it forward.
+    %{errors: translate_errors(changeset)}
+  end
+end

--- a/apps/whats_up_web/lib/whats_up_web/views/task_view.ex
+++ b/apps/whats_up_web/lib/whats_up_web/views/task_view.ex
@@ -1,0 +1,19 @@
+defmodule WhatsUpWeb.TaskView do
+  use WhatsUpWeb, :view
+  alias WhatsUpWeb.TaskView
+
+  def render("index.json", %{tasks: tasks}) do
+    %{data: render_many(tasks, TaskView, "task.json")}
+  end
+
+  def render("show.json", %{task: task}) do
+    %{data: render_one(task, TaskView, "task.json")}
+  end
+
+  def render("task.json", %{task: task}) do
+    %{id: task.id,
+      name: task.name,
+      upvote_count: task.upvote_count,
+      creator_id: task.creator_id}
+  end
+end

--- a/apps/whats_up_web/test/whats_up_web/controllers/task_controller_test.exs
+++ b/apps/whats_up_web/test/whats_up_web/controllers/task_controller_test.exs
@@ -1,0 +1,96 @@
+defmodule WhatsUpWeb.TaskControllerTest do
+  use WhatsUpWeb.ConnCase
+
+  alias WhatsUp.Directory
+  alias WhatsUp.Directory.Task
+
+  @create_attrs %{
+    creator_id: 42,
+    name: "some name",
+    upvote_count: 42
+  }
+  @update_attrs %{
+    creator_id: 43,
+    name: "some updated name",
+    upvote_count: 43
+  }
+  @invalid_attrs %{creator_id: nil, name: nil, upvote_count: nil}
+
+  def fixture(:task) do
+    {:ok, task} = Directory.create_task(@create_attrs)
+    task
+  end
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  describe "index" do
+    test "lists all tasks", %{conn: conn} do
+      conn = get(conn, Routes.task_path(conn, :index))
+      assert json_response(conn, 200)["data"] == []
+    end
+  end
+
+  describe "create task" do
+    test "renders task when data is valid", %{conn: conn} do
+      conn = post(conn, Routes.task_path(conn, :create), task: @create_attrs)
+      assert %{"id" => id} = json_response(conn, 201)["data"]
+
+      conn = get(conn, Routes.task_path(conn, :show, id))
+
+      assert %{
+               "id" => id,
+               "creator_id" => 42,
+               "name" => "some name",
+               "upvote_count" => 42
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn = post(conn, Routes.task_path(conn, :create), task: @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "update task" do
+    setup [:create_task]
+
+    test "renders task when data is valid", %{conn: conn, task: %Task{id: id} = task} do
+      conn = put(conn, Routes.task_path(conn, :update, task), task: @update_attrs)
+      assert %{"id" => ^id} = json_response(conn, 200)["data"]
+
+      conn = get(conn, Routes.task_path(conn, :show, id))
+
+      assert %{
+               "id" => id,
+               "creator_id" => 43,
+               "name" => "some updated name",
+               "upvote_count" => 43
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, task: task} do
+      conn = put(conn, Routes.task_path(conn, :update, task), task: @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "delete task" do
+    setup [:create_task]
+
+    test "deletes chosen task", %{conn: conn, task: task} do
+      conn = delete(conn, Routes.task_path(conn, :delete, task))
+      assert response(conn, 204)
+
+      assert_error_sent 404, fn ->
+        get(conn, Routes.task_path(conn, :show, task))
+      end
+    end
+  end
+
+  defp create_task(_) do
+    task = fixture(:task)
+    %{task: task}
+  end
+end


### PR DESCRIPTION
### Adds apis for tasks

#### Get all tasks api
`curl --location --request GET 'http://localhost:4000/api/tasks'`

#### Create new task api
```
curl --location --request POST 'http://localhost:4000/api/tasks' \
--header 'Content-Type: application/json' \
--data-raw '{
  "task" : {
    "name": "Bilding a new PC for Streaming",
    "upvote_count": 0,
    "creator_id": 2
  }
}'
```